### PR TITLE
CRM-25189 Remove kotlin from default sdks

### DIFF
--- a/.github/workflows/php-app.yml
+++ b/.github/workflows/php-app.yml
@@ -77,7 +77,7 @@ on:
         type: string
       sdks:
         description: 'List of sdks to build'
-        default: '["php", "typescript", "micronaut", "kotlin"]'
+        default: '["php", "typescript", "micronaut"]'
         required: false
         type: string
       sentry-project:


### PR DESCRIPTION
Ça va être plus simple de l'enlever dans les defaults q'overrider l'argument sdks partout.