### PR TITLE
Always use repo default branch as release branch

### DIFF
--- a/.github/workflows/php-app.yml
+++ b/.github/workflows/php-app.yml
@@ -246,7 +246,7 @@ jobs:
         id: metadata
         uses: equisoft-actions/application-metadata@v1
         with:
-          release-branch: master
+          release-branch: ${{ github.event.repository.default_branch }}
           hotfix-branch-prefix: release/
 
       - name: Setup asdf-vm

--- a/.github/workflows/php-library.yml
+++ b/.github/workflows/php-library.yml
@@ -115,7 +115,7 @@ jobs:
         uses : equisoft-actions/psalm@v2
         with:
           working-directory: ${{ inputs.working-directory }}
-          default-branch: master
+          default-branch: ${{ github.event.repository.default_branch }}
           extra-args: ${{ inputs.psalm-extra-args }}
           php-version: ${{ inputs.php-version }}
 
@@ -145,7 +145,7 @@ jobs:
         uses : equisoft-actions/phpcs@v2
         with:
           report-name: phpcs.php-${{ inputs.php-version }}.junit.xml
-          default-branch: master
+          default-branch: ${{ github.event.repository.default_branch }}
           working-directory: ${{ inputs.working-directory }}
           report-retention-days: ${{ inputs.report-retention-days }}
 


### PR DESCRIPTION
On a plan-us qui est sur `main` comme default branch et les workfow php fonctionne pas.

J'ai pas ajouté de paramètre parce qu'on release toujours sur la default branch (pour les projet qui utilise ces workflow en tk)